### PR TITLE
Use huisstijl compliant titlepage and minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.aux
+*.bbl
+*.blg
+*.fdb_latexmk
+*.fls
+*.log
+*.pdf
+*.synctex.gz
+*.toc

--- a/BachelorThesis.tex
+++ b/BachelorThesis.tex
@@ -9,11 +9,12 @@
 \usepackage{todonotes}
 \usepackage{array}
 \usepackage{listings}
-\usepackage[a4paper]{geometry}
+\usepackage{rutitlepage}
+\usepackage{geometry}
 \usepackage{float}
 
 \makeatletter %otherwise geometry resets everything
-\Gm@restore@org
+\Gm@restore@org%
 \makeatother
 
 \setlength{\itemsep}{0cm}
@@ -27,41 +28,16 @@
 \graphicspath{{imgs/}}
 
 \begin{document}
-\begin{titlepage}
-\begin{center}
-\textsc{\LARGE Bachelor thesis\\Computer Science}\\[1.5cm]
-\includegraphics[height=100pt]{logo}
-
-\vspace{0.4cm}
-\textsc{\Large Radboud University}\\[1cm]
-\hrule
-\vspace{0.4cm}
-\textbf{\huge Thesis Title\\[0.3cm]
-\LARGE Subtitle if you like
-}\\[0.4cm]
-\hrule
-\vspace{2cm}
-\begin{minipage}[t]{0.45\textwidth}
-\begin{flushleft} \large
-\textit{Author:}\\
-Firstname Lastname\\
-sXXXXXX
-\end{flushleft}
-\end{minipage}
-\begin{minipage}[t]{0.45\textwidth}
-\begin{flushright} \large
-\textit{First supervisor/assessor:}\\
-Prof.dr.ir. Arjen P. de Vries\\
-\texttt{arjen@cs.ru.nl}\\[1.3cm]
-\textit{Second assessor:}\\
-Firstname Lastname\\
-\texttt{NAME@cs.ru.nl}
-\end{flushright}
-\end{minipage}
-\vfill
-{\large \today}
-\end{center}
-\end{titlepage}
+\maketitleru[
+	authors={Firstname Lastname\\sXXXXXX},
+	date={\today},
+	others={%
+		{First supervisor/assessor:}{Prof.\ dr.\ ir.\ Arjen P.\ de Vries},
+		{Second assessor:}{Firstname Lastname}},
+	course={Bachelor's Thesis Computing Science},
+	title={Thesis Title},
+	subtitle={Subtitle if you like},
+]
 
 \input{abstract}
 \tableofcontents

--- a/introduction.tex
+++ b/introduction.tex
@@ -1,3 +1,5 @@
 \chapter{Introduction}\label{ch:intro}
 
 Introduce the topic of the thesis, including research questions.
+
+Starting a new paragraph is done by inserting an empty line like this.

--- a/relatedwork.tex
+++ b/relatedwork.tex
@@ -1,3 +1,3 @@
 \chapter{Related Work}\label{ch:rel}
 
-In 2016 Han Veiga and Eickhoff collected a dataset of 850 authentic English-speaking users across Twitter, Instagram and Foursquare \cite{OSN}. Blablabla.
+In 2016 Han Veiga and Eickhoff collected a dataset of 850 authentic English-speaking users across Twitter, Instagram and Foursquare~\cite{OSN}. Blablabla.


### PR DESCRIPTION
This MR:

- Changes the titlepage to the [rutitlepage](https://www.ctan.org/pkg/rutitlepage) package, a somewhat huisstijl compliant titlepage.The RU huisstijl dictates that the shield not be used without the text.
https://www.radboudnet.nl/communicatie/huisstijl/logo/
The [rutitlepage](https://www.ctan.org/pkg/rutitlepage) package provides a somewhat huisstijl compliant titlepage.
- Add a .gitignore so that students who use overleaf's git functionality don't accidentally push intermediate files
- Change the space before the citation to a non-breaking space to avoid an accidental pagebreak just before the citation
- Shows how to create a new paragraph in LaTeX. This is an often made error by students. 


